### PR TITLE
linux: support ignore regex pattern

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -5,7 +5,8 @@
         "sources": [
             "src/NSFW.cpp",
             "src/Queue.cpp",
-            "src/NativeInterface.cpp"
+            "src/NativeInterface.cpp",
+            "src/PathFilter.cpp"
         ],
         "include_dirs": [
             "includes",
@@ -102,7 +103,7 @@
                 ],
                 "libraries": [
                     "-L/usr/local/lib",
-                    "-linotify" 
+                    "-linotify"
                 ]
             }],
         ]

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ const nsfw = require('@theia/nsfw');
  - **options**
    - **debounceMS**: time in milliseconds to debounce the event callback
    - **errorCallback**: callback to fire in the case of errors
+   - **ignorePathRegexArray**: string array with regex patterns to ignore paths
 
 
   Returns a Promise that resolves to the created NSFW Object.

--- a/includes/NSFW.h
+++ b/includes/NSFW.h
@@ -10,6 +10,7 @@
 
 #include "./Queue.h"
 #include "./NativeInterface.h"
+#include "./PathFilter.h"
 
 class NSFW : public Napi::ObjectWrap<NSFW> {
   private:
@@ -23,6 +24,7 @@ class NSFW : public Napi::ObjectWrap<NSFW> {
     std::unique_ptr<NativeInterface> mInterface;
     std::mutex mInterfaceLock;
     std::shared_ptr<EventQueue> mQueue;
+    std::shared_ptr<PathFilter> mPathFilter;
     std::string mPath;
     std::thread mPollThread;
     std::atomic<bool> mRunning;

--- a/includes/NativeInterface.h
+++ b/includes/NativeInterface.h
@@ -13,11 +13,15 @@ using NativeImplementation = InotifyService;
 #endif
 
 #include "Queue.h"
+#include "PathFilter.h"
 #include <vector>
 
 class NativeInterface {
 public:
-  NativeInterface(const std::string &path, std::shared_ptr<EventQueue> queue);
+  NativeInterface(
+    const std::string &path,
+    std::shared_ptr<EventQueue> queue,
+    std::shared_ptr<PathFilter> pathFilter);
   ~NativeInterface();
 
   std::string getError();
@@ -26,6 +30,7 @@ public:
 
 private:
   std::unique_ptr<NativeImplementation> mNativeInterface;
+  std::shared_ptr<PathFilter> mPathFilter;
 };
 
 #endif

--- a/includes/PathFilter.h
+++ b/includes/PathFilter.h
@@ -1,0 +1,22 @@
+#ifndef FILTER_H
+#define FILTER_H
+
+#include <regex>
+#include <string>
+#include <vector>
+
+class PathFilter {
+    private:
+        std::vector<std::regex> mIgnorePathRegexVector;
+
+    public:
+        PathFilter();
+        ~PathFilter();
+
+        /** add a regex to the internal list of ignore filters */
+        void addIgnoreRegex(const std::regex &re);
+        /** return true if path should be ignored, false otherwise */
+        bool ignorePath(const std::string &path);
+};
+
+#endif

--- a/includes/Queue.h
+++ b/includes/Queue.h
@@ -1,6 +1,8 @@
 #ifndef NSFW_QUEUE_H
 #define NSFW_QUEUE_H
 
+#include "./PathFilter.h"
+
 #include <string>
 #include <memory>
 #include <deque>
@@ -39,6 +41,7 @@ public:
   std::size_t count();
   std::unique_ptr<Event> dequeue();
   std::unique_ptr<std::vector<std::unique_ptr<Event>>> dequeueAll();
+  std::unique_ptr<std::vector<std::unique_ptr<Event>>> dequeueAll(const std::shared_ptr<PathFilter> &pathFilter);
   void enqueue(
     const EventType type,
     const std::string &fromDirectory,

--- a/includes/linux/InotifyService.h
+++ b/includes/linux/InotifyService.h
@@ -4,6 +4,7 @@
 #include "InotifyEventLoop.h"
 #include "InotifyTree.h"
 #include "../Queue.h"
+#include "../PathFilter.h"
 #include <queue>
 #include <map>
 
@@ -12,7 +13,7 @@ class InotifyTree;
 
 class InotifyService {
 public:
-  InotifyService(std::shared_ptr<EventQueue> queue, std::string path);
+  InotifyService(std::shared_ptr<EventQueue> queue, std::string path, std::shared_ptr<PathFilter> pathFilter);
 
   std::string getError();
   bool hasErrored();

--- a/includes/linux/InotifyTree.h
+++ b/includes/linux/InotifyTree.h
@@ -11,9 +11,11 @@
 #include <map>
 #include <unordered_set>
 
+#include "../PathFilter.h"
+
 class InotifyTree {
 public:
-  InotifyTree(int inotifyInstance, std::string path);
+  InotifyTree(int inotifyInstance, std::string path, std::shared_ptr<PathFilter> pathFilter);
 
   void addDirectory(int wd, std::string name);
   std::string getError();
@@ -31,6 +33,7 @@ private:
     InotifyNode(
       InotifyTree *tree,
       int inotifyInstance,
+      std::shared_ptr<PathFilter> pathFilter,
       InotifyNode *parent,
       std::string directory,
       std::string name,
@@ -68,6 +71,7 @@ private:
     std::string mFullPath;
     ino_t mInodeNumber;
     const int mInotifyInstance;
+    std::shared_ptr<PathFilter> mPathFilter;
     std::string mName;
     InotifyNode *mParent;
     InotifyTree *mTree;
@@ -83,6 +87,7 @@ private:
 
   std::string mError;
   const int mInotifyInstance;
+  std::shared_ptr<PathFilter> mPathFilter;
   std::map<int, InotifyNode *> *mInotifyNodeByWatchDescriptor;
   std::unordered_set<ino_t> inodes;
   InotifyNode *mRoot;

--- a/includes/osx/FSEventsService.h
+++ b/includes/osx/FSEventsService.h
@@ -3,6 +3,7 @@
 
 #include "RunLoop.h"
 #include "../Queue.h"
+#include "../PathFilter.h"
 
 #include <CoreServices/CoreServices.h>
 #include <time.h>
@@ -24,7 +25,7 @@ class RunLoop;
 
 class FSEventsService {
 public:
-  FSEventsService(std::shared_ptr<EventQueue> queue, std::string path);
+  FSEventsService(std::shared_ptr<EventQueue> queue, std::string path, std::shared_ptr<PathFilter> pathFilter);
 
   friend void FSEventsServiceCallback(
     ConstFSEventStreamRef streamRef,

--- a/includes/win32/Controller.h
+++ b/includes/win32/Controller.h
@@ -4,12 +4,13 @@
 #include <string>
 #include <memory>
 #include "Watcher.h"
+#include "../PathFilter.h"
 
 class EventQueue;
 
 class Controller {
   public:
-    Controller(std::shared_ptr<EventQueue> queue, const std::string &path);
+    Controller(std::shared_ptr<EventQueue> queue, const std::string &path, std::shared_ptr<PathFilter> pathFilter);
 
     std::string getError();
     bool hasErrored();

--- a/index.d.ts
+++ b/index.d.ts
@@ -23,6 +23,8 @@ declare module '@theia/nsfw' {
             debounceMS?: number;
             /** callback to fire in the case of errors */
             errorCallback: (err: any) => void;
+            /** js regex array to filter which path to watch or not */
+            ignorePathRegexArray: string[];
         }
 
         /** mapping object representing all the ActionType enum values */

--- a/js/spec/index-spec.js
+++ b/js/spec/index-spec.js
@@ -534,6 +534,59 @@ describe('Node Sentinel File Watcher', function() {
         watch = null;
       }
     });
+
+    if (process.platform === 'linux') {
+      it('can cut part of the watch tree (linux)', async function () {
+        const path4 = path.resolve(workDir, 'test4');
+        const path3 = path.resolve(workDir, 'test3');
+        let deletionCountErrors = 0;
+        let deletionCount = 0;
+
+        function findEvent(element) {
+          if (element.action === nsfw.actions.DELETED)
+          {
+            if (element.directory === path.resolve(path4))
+            {
+              deletionCountErrors++;
+            }
+            else if (element.directory === workDir && element.file === 'test4')
+            {
+              deletionCountErrors++;
+            }
+            else if (element.directory === path.resolve(path3)
+                && (element.file === 'testing3.file' || element.file === 'folder3'))
+            {
+              deletionCount++;
+            }
+            else if (element.directory === workDir && element.file === 'test3')
+            {
+              deletionCount++;
+            }
+          }
+        }
+
+        let watch = await nsfw(
+          workDir,
+          events => events.forEach(findEvent),
+          { debounceMS: DEBOUNCE, ignorePathRegexArray: [ '.*/test4.*' ] }
+        );
+
+        try {
+          await watch.start();
+          await sleep(TIMEOUT_PER_STEP);
+          await fse.remove(path4);
+          await sleep(TIMEOUT_PER_STEP);
+          await fse.remove(path3);
+          await sleep(TIMEOUT_PER_STEP);
+
+          assert.ok(deletionCountErrors === 0);
+          assert.ok(deletionCount > 2);
+        } finally {
+          await watch.stop();
+          watch = null;
+        }
+      });
+    }
   });
 
   describe('Errors', function() {

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -48,7 +48,11 @@ function NSFWFilePoller(watchPath, eventCallback, debounceMS) {
 }
 
 
-const buildNSFW = async (watchPath, eventCallback, { debounceMS = 500, errorCallback: _errorCallback } = {}) => {
+const buildNSFW = async (watchPath, eventCallback, {
+  debounceMS = 500,
+  errorCallback: _errorCallback,
+  ignorePathRegexArray
+} = {}) => {
   if (Number.isInteger(debounceMS)) {
     if (debounceMS < 1) {
       throw new Error('Minimum debounce is 1ms.');
@@ -71,7 +75,7 @@ const buildNSFW = async (watchPath, eventCallback, { debounceMS = 500, errorCall
   }
 
   if (stats.isDirectory()) {
-    return new NSFW(watchPath, eventCallback, { debounceMS, errorCallback });
+    return new NSFW(watchPath, eventCallback, { debounceMS, errorCallback, ignorePathRegexArray });
   } else if (stats.isFile()) {
     return new NSFWFilePoller(watchPath, eventCallback, debounceMS);
   } else {

--- a/src/NativeInterface.cpp
+++ b/src/NativeInterface.cpp
@@ -1,7 +1,7 @@
 #include "../includes/NativeInterface.h"
 
-NativeInterface::NativeInterface(const std::string &path, std::shared_ptr<EventQueue> queue) {
-  mNativeInterface.reset(new NativeImplementation(queue, path));
+NativeInterface::NativeInterface(const std::string &path, std::shared_ptr<EventQueue> queue, std::shared_ptr<PathFilter> pathFilter) {
+  mNativeInterface.reset(new NativeImplementation(queue, path, pathFilter));
 }
 
 NativeInterface::~NativeInterface() {

--- a/src/PathFilter.cpp
+++ b/src/PathFilter.cpp
@@ -1,0 +1,20 @@
+#include "../includes/PathFilter.h"
+
+#pragma unmanaged
+
+PathFilter::PathFilter() {}
+PathFilter::~PathFilter() {}
+
+void PathFilter::addIgnoreRegex(const std::regex &re) {
+  mIgnorePathRegexVector.push_back(re);
+}
+
+bool PathFilter::ignorePath(const std::string &path) {
+  std::smatch match;
+  for (std::regex re : mIgnorePathRegexVector) {
+    if (std::regex_match(path, match, re)) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/src/Queue.cpp
+++ b/src/Queue.cpp
@@ -1,5 +1,7 @@
 #include "../includes/Queue.h"
+#include <cstdio>
 #include <iostream>
+#include <memory>
 
 #pragma unmanaged
 
@@ -36,6 +38,30 @@ std::unique_ptr<std::vector<std::unique_ptr<Event>>> EventQueue::dequeueAll() {
   std::unique_ptr<std::vector<std::unique_ptr<Event>>> events(new std::vector<std::unique_ptr<Event>>);
   for (size_t i = 0; i < queueSize; ++i) {
     auto &front = queue.front();
+    events->emplace_back(std::move(front));
+    queue.pop_front();
+  }
+
+  return events;
+}
+
+std::unique_ptr<std::vector<std::unique_ptr<Event>>> EventQueue::dequeueAll(const std::shared_ptr<PathFilter> &pathFilter) {
+  std::lock_guard<std::mutex> lock(mutex);
+  if (queue.empty()) {
+    return nullptr;
+  }
+
+  const auto queueSize = queue.size();
+  std::unique_ptr<std::vector<std::unique_ptr<Event>>> events(new std::vector<std::unique_ptr<Event>>);
+  for (size_t i = 0; i < queueSize; ++i) {
+    auto &front = queue.front();
+    if (
+      pathFilter->ignorePath(front->fromDirectory + "/" + front->fromFile) ||
+      (front->type == EventType::RENAMED && pathFilter->ignorePath(front->toDirectory + "/" + front->toFile))
+    ) {
+      queue.pop_front();
+      continue;
+    }
     events->emplace_back(std::move(front));
     queue.pop_front();
   }

--- a/src/linux/InotifyService.cpp
+++ b/src/linux/InotifyService.cpp
@@ -1,6 +1,6 @@
 #include "../../includes/linux/InotifyService.h"
 
-InotifyService::InotifyService(std::shared_ptr<EventQueue> queue, std::string path):
+InotifyService::InotifyService(std::shared_ptr<EventQueue> queue, std::string path, std::shared_ptr<PathFilter> pathFilter):
   mEventLoop(NULL),
   mQueue(queue),
   mTree(NULL) {
@@ -10,7 +10,7 @@ InotifyService::InotifyService(std::shared_ptr<EventQueue> queue, std::string pa
     return;
   }
 
-  mTree = new InotifyTree(mInotifyInstance, path);
+  mTree = new InotifyTree(mInotifyInstance, path, pathFilter);
   if (!mTree->isRootAlive()) {
     delete mTree;
     mTree = NULL;

--- a/src/linux/InotifyTree.cpp
+++ b/src/linux/InotifyTree.cpp
@@ -2,9 +2,10 @@
 /**
  * InotifyTree ---------------------------------------------------------------------------------------------------------
  */
-InotifyTree::InotifyTree(int inotifyInstance, std::string path):
+InotifyTree::InotifyTree(int inotifyInstance, std::string path, std::shared_ptr<PathFilter> pathFilter):
   mError(""),
-  mInotifyInstance(inotifyInstance) {
+  mInotifyInstance(inotifyInstance),
+  mPathFilter(pathFilter) {
   mInotifyNodeByWatchDescriptor = new std::map<int, InotifyNode *>;
 
   std::string directory;
@@ -28,6 +29,7 @@ InotifyTree::InotifyTree(int inotifyInstance, std::string path):
   mRoot = new InotifyNode(
     this,
     mInotifyInstance,
+    mPathFilter,
     NULL,
     directory,
     watchName,
@@ -159,6 +161,7 @@ InotifyTree::~InotifyTree() {
 InotifyTree::InotifyNode::InotifyNode(
   InotifyTree *tree,
   int inotifyInstance,
+  std::shared_ptr<PathFilter> pathFilter,
   InotifyNode *parent,
   std::string directory,
   std::string name,
@@ -167,6 +170,7 @@ InotifyTree::InotifyNode::InotifyNode(
   mDirectory(directory),
   mInodeNumber(inodeNumber),
   mInotifyInstance(inotifyInstance),
+  mPathFilter(pathFilter),
   mName(name),
   mParent(parent),
   mTree(tree) {
@@ -201,6 +205,10 @@ InotifyTree::InotifyNode::InotifyNode(
 
     std::string filePath = createFullPath(mFullPath, fileName);
 
+    if (mPathFilter->ignorePath(filePath)) {
+      continue;
+    }
+
     struct stat file;
 
     if (
@@ -214,6 +222,7 @@ InotifyTree::InotifyNode::InotifyNode(
     InotifyNode *child = new InotifyNode(
       mTree,
       mInotifyInstance,
+      mPathFilter,
       this,
       mFullPath,
       fileName,
@@ -256,6 +265,7 @@ void InotifyTree::InotifyNode::addChild(std::string name) {
     InotifyNode *child = new InotifyNode(
       mTree,
       mInotifyInstance,
+      mPathFilter,
       this,
       mFullPath,
       name,

--- a/src/osx/FSEventsService.cpp
+++ b/src/osx/FSEventsService.cpp
@@ -1,7 +1,7 @@
 #include "../../includes/osx/FSEventsService.h"
 #include <iostream>
 
-FSEventsService::FSEventsService(std::shared_ptr<EventQueue> queue, std::string path):
+FSEventsService::FSEventsService(std::shared_ptr<EventQueue> queue, std::string path, std::shared_ptr<PathFilter> pathFilter):
   mPath(path), mQueue(queue) {
   mRunLoop = new RunLoop(this, path);
 

--- a/src/win32/Controller.cpp
+++ b/src/win32/Controller.cpp
@@ -54,7 +54,7 @@ HANDLE Controller::openDirectory(const std::wstring &path) {
          );
 }
 
-Controller::Controller(std::shared_ptr<EventQueue> queue, const std::string &path)
+Controller::Controller(std::shared_ptr<EventQueue> queue, const std::string &path, std::shared_ptr<PathFilter> pathFilter)
   : mDirectoryHandle(INVALID_HANDLE_VALUE)
 {
   auto widePath = convertMultiByteToWideChar(path);


### PR DESCRIPTION
This is a first pass at implementing some mechanism to filter paths.
Right now, we use the regex engine from the C++ standard library, but
this engine behaves differently than the most common one used by recent
JS runtimes.

Signed-off-by: Paul Maréchal <paul.marechal@ericsson.com>